### PR TITLE
logout on token expire

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -11,9 +11,29 @@ import SettingsMenu from '../containers/SettingsMenu'
 import UpdateProfileForm from '../containers/UpdateProfileForm'
 import GymStatus from './GymStatus'
 import { Redirect } from 'react-router-dom'
+import request from 'superagent'
+import * as constants from '../constants'
 import './App.css'
 
 class App extends React.Component {
+    constructor(props) {
+        super(props)
+
+        this.facebookLogout = this.facebookLogout.bind(this)
+    }
+
+    componentDidMount() {
+        request
+            .get(constants.GAL_BACKEND_PROFILE_URL)
+            .auth(this.props.userInfo.id, this.props.userInfo.accessToken)
+            .end(this.facebookLogout)
+    }
+
+    facebookLogout(err, resp) {
+        if (err && err.status === 401) {
+            this.props.handleLogout()
+        }
+    }
 
     render() {
         let content, appbar

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -1,8 +1,10 @@
 import appcomponent from '../components/App'
 import { connect } from 'react-redux'
+import { facebookLogout } from '../actions'
 
 const mapStateToProps = state => {
     return {
+        userInfo: state.userFacebookInfo,
         loggedIn: state.loggedIn,
         signedUp: state.signedUp,
         currentPage: state.currentPage,
@@ -10,7 +12,11 @@ const mapStateToProps = state => {
 }
 
 const mapDispatchToProps = dispatch => {
-    return {}
+    return {
+        handleLogout: () => {
+            dispatch(facebookLogout())
+        }
+    }
 }
 
 const App = connect(


### PR DESCRIPTION
The production backend does not accept expired tokens. When this happens the user should be automatically logged out so they can log in again for a new token.